### PR TITLE
Updated for Node 0.10.x

### DIFF
--- a/src/perl_bindings.cc
+++ b/src/perl_bindings.cc
@@ -547,3 +547,4 @@ extern "C" void init(Handle<Object> target) {
     NodePerlMethod::Init(target);
 }
 
+NODE_MODULE(perl, init)


### PR DESCRIPTION
Node 0.10.x requires addons to register using the NODE_MODULE macro.

Fixes #2
