### PR TITLE
Update package.json - move nan to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "nan": "^2.7.0"
+  },
   "devDependencies": {
-    "nan": "^2.7.0",
     "tap": "~0.3.1"
   },
   "scripts": {


### PR DESCRIPTION
Totally overlooked the fact that `nan` needed to be in the `dependencies` section when installing on a non development machine... whoops.